### PR TITLE
Fix duplicate approved donors memo name

### DIFF
--- a/app/(tabs)/stammtisch/[id].tsx
+++ b/app/(tabs)/stammtisch/[id].tsx
@@ -728,7 +728,7 @@ export default function StammtischEditScreen() {
     () => donors.filter(d => !!d.approved_at && d.first_due_stammtisch_id == null),
     [donors]
   )
-  const approvedDonors = useMemo(
+  const approvedExtraDonors = useMemo(
     () => donorExtras.filter(d => !!d.approved_at),
     [donorExtras]
   )


### PR DESCRIPTION
## Summary
- rename the extra donors memo to avoid duplicating the approvedDonors identifier

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68d3a9eefd908326a242225af5753a25