### PR TITLE
Restore donor extras memo chain

### DIFF
--- a/app/(tabs)/stammtisch/[id].tsx
+++ b/app/(tabs)/stammtisch/[id].tsx
@@ -724,11 +724,11 @@ export default function StammtischEditScreen() {
   )
 
   // nur bestätigte Spender oben anzeigen
-  const approvedDonors = useMemo(
-    () => donors.filter(d => !!d.approved_at && d.first_due_stammtisch_id == null),
+  const donorExtras = useMemo(
+    () => donors.filter(d => d.first_due_stammtisch_id == null),
     [donors]
   )
-  const approvedDonors = useMemo(
+  const approvedExtraDonors = useMemo(
     () => donorExtras.filter(d => !!d.approved_at),
     [donorExtras]
   )
@@ -754,43 +754,12 @@ export default function StammtischEditScreen() {
     return null
   }
 
-  const dueRoundLookup = useMemo(() => {
-    const map = new Map<string, BR>()
-    for (const round of dueRounds) {
-      const monthKey = round.due_month.slice(0, 7)
-      if (round.auth_user_id) {
-        map.set(`auth:${round.auth_user_id}|${monthKey}`, round)
-      }
-      if (round.profile_id != null) {
-        map.set(`profile:${round.profile_id}|${monthKey}`, round)
-      }
-    }
-    return map
-  }, [dueRounds])
-
-  const findDueRoundFor = useCallback(
-    (authUserId: string | null | undefined, profileId: number | null | undefined, monthYYYYMM: string) => {
-      if (!monthYYYYMM) return null
-      if (authUserId) {
-        const byAuth = dueRoundLookup.get(`auth:${authUserId}|${monthYYYYMM}`)
-        if (byAuth) return byAuth
-      }
-      if (profileId != null) {
-        const byProfile = dueRoundLookup.get(`profile:${profileId}|${monthYYYYMM}`)
-        if (byProfile) return byProfile
-      }
-      return null
-    },
-    [dueRoundLookup]
-  )
-
   const checkGiven = (authUserId: string | null, profileId: number | null, monthYYYYMM: string) => {
-    const round = resolveDueRound(authUserId, profileId, monthYYYYMM)
-    if (round && round.settled_stammtisch_id && round.settled_at) return true
+    const dueRound = resolveDueRound(authUserId, profileId, monthYYYYMM)
+    if (dueRound && dueRound.settled_stammtisch_id && dueRound.settled_at) return true
     if (authUserId && givenLinkedByMonth.get(authUserId)?.has(monthYYYYMM)) return true
     if (profileId != null && givenUnlinkedByMonth.get(profileId)?.has(monthYYYYMM)) return true
-    const round = findDueRoundFor(authUserId, profileId, monthYYYYMM)
-    if (round && (round.settled_stammtisch_id != null || !!round.settled_at)) return true
+    if (dueRound && (dueRound.settled_stammtisch_id != null || !!dueRound.settled_at)) return true
     return false
   }
 
@@ -907,7 +876,7 @@ export default function StammtischEditScreen() {
                         // bereits gegeben (pending oder approved)?
                         const hasGiven = checkGiven(p.auth_user_id, p.id, currentMonthYYYYMM)
 
-                        const roundForMonth = findDueRoundFor(p.auth_user_id, p.id, currentMonthYYYYMM)
+                        const dueRoundForMonth = resolveDueRound(p.auth_user_id, p.id, currentMonthYYYYMM)
 
                         // pending speziell (für evtl. Styling)
                         const pendingFromDonors =
@@ -916,9 +885,9 @@ export default function StammtischEditScreen() {
                             : (pendingUnlinkedMonthsByProfile.get(p.id)?.has(currentMonthYYYYMM) ?? false)
 
                         const pendingFromRound =
-                          !!roundForMonth &&
-                          (roundForMonth.settled_stammtisch_id != null || !!roundForMonth.settled_at) &&
-                          !roundForMonth.approved_at
+                          !!dueRoundForMonth &&
+                          (dueRoundForMonth.settled_stammtisch_id != null || !!dueRoundForMonth.settled_at) &&
+                          !dueRoundForMonth.approved_at
 
                         const isPending = pendingFromDonors || pendingFromRound
 
@@ -1074,11 +1043,11 @@ export default function StammtischEditScreen() {
                   <View style={{ padding: 8, alignItems: 'center' }}>
                     <ActivityIndicator color={colors.gold} />
                   </View>
-                ) : approvedDonors.length === 0 ? (
+                ) : approvedExtraDonors.length === 0 ? (
                   <Text style={type.body}>Noch keine bestätigten Runden.</Text>
                 ) : (
                   <ScrollView style={{ maxHeight: 220 }} contentContainerStyle={{ paddingBottom: 6 }} showsVerticalScrollIndicator>
-                    {approvedDonors.map((d) => {
+                    {approvedExtraDonors.map((d) => {
                       const prof = findProfileBy(d.auth_user_id, d.profile_id)
                       const name = prof ? fullName(prof) : (d.auth_user_id ?? 'Unverknüpft')
                       const avatar = avatarUrlFor(prof || null)


### PR DESCRIPTION
## Summary
- restore the donor extras memo chain so the approved extra donor list is derived once without duplicate identifiers

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a9eefd908326a242225af5753a25